### PR TITLE
evdns: port fix searching empty hostnames

### DIFF
--- a/TMessagesProj/jni/voip/webrtc/base/third_party/libevent/evdns.c
+++ b/TMessagesProj/jni/voip/webrtc/base/third_party/libevent/evdns.c
@@ -2496,8 +2496,12 @@ search_set_from_hostname(void) {
 static char *
 search_make_new(const struct search_state *const state, int n, const char *const base_name) {
 	const int base_len = strlen(base_name);
-	const char need_to_append_dot = base_name[base_len - 1] == '.' ? 0 : 1;
+	char need_to_append_dot;
 	struct search_domain *dom;
+
+	if (!base_len) return NULL;
+ 	need_to_append_dot = base_name[base_len - 1] == '.' ? 0 : 1;
+ 
 
 	for (dom = state->head; dom; dom = dom->next) {
 		if (!n--) {


### PR DESCRIPTION
Porting a fix from thirdparty libevent that has not been applied here yet

### Original Issue
When `base_name` is an empty string, the code accesses `base_name[base_len - 1]` (where `base_len` is 0), resulting in a heap buffer overflow read that can cause crashes.

### References
Original fix here:
https://github.com/libevent/libevent/commit/ec65c42052d95d2c23d1d837136d1cf1d9ecef9e