### PR TITLE
Disable notification summary

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
@@ -4191,7 +4191,7 @@ public class NotificationsController extends BaseController {
                 } else {
                     detailText = "";
                 }
-                if (pushDialogs.size() != 1 || Build.VERSION.SDK_INT < 23) {
+                if (!NekoConfig.disableNotificationSummary && (pushDialogs.size() != 1 || Build.VERSION.SDK_INT < 23)) {
                     if (pushDialogs.size() == 1) {
                         detailText += LocaleController.formatPluralString("NewMessages", total_unread_count);
                     } else {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
@@ -129,6 +129,7 @@ public class NekoConfig {
     public static boolean tryToOpenAllLinksInIV = false;
     public static boolean formatTimeWithSeconds = false;
     public static boolean accentAsNotificationColor = false;
+    public static boolean disableNotificationSummary = false;
     public static boolean silenceNonContacts = false;
     public static boolean disableJumpToNextChannel = false;
     public static boolean disableVoiceMessageAutoPlay = false;
@@ -222,6 +223,7 @@ public class NekoConfig {
             tryToOpenAllLinksInIV = preferences.getBoolean("tryToOpenAllLinksInIV", false);
             formatTimeWithSeconds = preferences.getBoolean("formatTimeWithSeconds", false);
             accentAsNotificationColor = preferences.getBoolean("accentAsNotificationColor", false);
+            disableNotificationSummary = preferences.getBoolean("disableNotificationSummary", false);
             silenceNonContacts = preferences.getBoolean("silenceNonContacts", false);
             showNoQuoteForward = preferences.getBoolean("showNoQuoteForward", false);
             wsEnableTLS = preferences.getBoolean("wsEnableTLS", true);
@@ -916,6 +918,14 @@ public class NekoConfig {
         SharedPreferences preferences = ApplicationLoader.applicationContext.getSharedPreferences("nekoconfig", Activity.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences.edit();
         editor.putBoolean("accentAsNotificationColor", accentAsNotificationColor);
+        editor.apply();
+    }
+
+    public static void toggleDisableNotificationSummary() {
+        disableNotificationSummary = !disableNotificationSummary;
+        SharedPreferences preferences = ApplicationLoader.applicationContext.getSharedPreferences("nekoconfig", Activity.MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putBoolean("disableNotificationSummary", disableNotificationSummary);
         editor.apply();
     }
 

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoGeneralSettingsActivity.java
@@ -47,6 +47,7 @@ public class NekoGeneralSettingsActivity extends BaseNekoSettingsActivity {
 
     private int notificationRow;
     private int accentAsNotificationColorRow;
+    private int disableNotificationSummaryRow;
     private int silenceNonContactsRow;
     private int notification2Row;
 
@@ -156,6 +157,11 @@ public class NekoGeneralSettingsActivity extends BaseNekoSettingsActivity {
             if (view instanceof TextCheckCell) {
                 ((TextCheckCell) view).setChecked(NekoConfig.accentAsNotificationColor);
             }
+        }  else if (position == disableNotificationSummaryRow) {
+            NekoConfig.toggleDisableNotificationSummary();
+            if (view instanceof TextCheckCell) {
+                ((TextCheckCell) view).setChecked(NekoConfig.disableNotificationSummary);
+            }
         } else if (position == silenceNonContactsRow) {
             NekoConfig.toggleSilenceNonContacts();
             if (view instanceof TextCheckCell) {
@@ -257,6 +263,7 @@ public class NekoGeneralSettingsActivity extends BaseNekoSettingsActivity {
 
         notificationRow = addRow("notification");
         accentAsNotificationColorRow = addRow("accentAsNotificationColor");
+        disableNotificationSummaryRow = addRow("disableNotificationSummary");
         silenceNonContactsRow = addRow("silenceNonContacts");
         notification2Row = addRow();
 
@@ -385,6 +392,8 @@ public class NekoGeneralSettingsActivity extends BaseNekoSettingsActivity {
                         textCell.setTextAndCheck(LocaleController.getString(R.string.AskBeforeCalling), NekoConfig.askBeforeCall, divider);
                     } else if (position == accentAsNotificationColorRow) {
                         textCell.setTextAndCheck(LocaleController.getString(R.string.AccentAsNotificationColor), NekoConfig.accentAsNotificationColor, divider);
+                    } else if (position == disableNotificationSummaryRow) {
+                        textCell.setTextAndCheck(LocaleController.getString(R.string.DisableNotificationSummary), NekoConfig.disableNotificationSummary, divider);
                     } else if (position == silenceNonContactsRow) {
                         textCell.setTextAndCheck(LocaleController.getString(R.string.SilenceNonContacts), NekoConfig.silenceNonContacts, divider);
                     } else if (position == autoTranslateRow) {

--- a/TMessagesProj/src/main/res/values/strings_neko.xml
+++ b/TMessagesProj/src/main/res/values/strings_neko.xml
@@ -114,6 +114,7 @@
     <string name="BlurAvatarBackground">Blur profile picture</string>
     <string name="DarkenAvatarBackground">Darken profile picture</string>
     <string name="AccentAsNotificationColor">Accent color as notification color</string>
+    <string name="DisableNotificationSummary">Disable notification summary</string>
     <string name="SilenceNonContacts">Silence Non-Contacts</string>
     <string name="SilenceNonContactsAbout">Notifications from people that are not your contacts will appear without sound. You can add users to contacts from their profile without knowing their phone number.</string>
     <string name="SelectBetween">Select between</string>


### PR DESCRIPTION
Removes "X new messages from Y chats" from notification's _subText_ field.

This additional message does not appear on my Pixel 9 phone, but it does appear on my smartwatch before the actual message and takes up most of the screen space. 

The setting is called **Disable notification summary** and is located on the **General** settings page after **Accent color as notification color** setting.