### PR TITLE
Prevent auth token leakage through debug logs and cloud backups

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/AuthTokensHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AuthTokensHelper.java
@@ -81,9 +81,6 @@ public class AuthTokensHelper {
     }
 
     public static void saveLogInToken(TLRPC.TL_auth_authorization token) {
-        if (BuildVars.DEBUG_VERSION) {
-            FileLog.d("saveLogInToken " + new String(token.future_auth_token, StandardCharsets.UTF_8));
-        }
         ArrayList<TLRPC.TL_auth_authorization> tokens = getSavedLogInTokens();
         if (tokens == null) {
             tokens = new ArrayList<>();
@@ -108,7 +105,7 @@ public class AuthTokensHelper {
                 editor.putString("log_in_token_" + i, Utilities.bytesToHex(data.toByteArray()));
             }
             editor.apply();
-            BackupAgent.requestBackup(ApplicationLoader.applicationContext);
+            // BackupAgent.requestBackup(ApplicationLoader.applicationContext);
         }
     }
 
@@ -118,7 +115,7 @@ public class AuthTokensHelper {
         SerializedData data = new SerializedData(response.getObjectSize());
         response.serializeToStream(data);
         preferences.edit().putString("log_out_token_" + count, Utilities.bytesToHex(data.toByteArray())).putInt("count", count + 1).apply();
-        BackupAgent.requestBackup(ApplicationLoader.applicationContext);
+        // BackupAgent.requestBackup(ApplicationLoader.applicationContext);
     }
 
     public static void clearLogInTokens() {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/BackupAgent.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/BackupAgent.java
@@ -22,7 +22,7 @@ public class BackupAgent extends BackupAgentHelper {
 
     @Override
     public void onCreate() {
-        SharedPreferencesBackupHelper helper = new SharedPreferencesBackupHelper(this, "saved_tokens", "saved_tokens_login");
+        SharedPreferencesBackupHelper helper = new SharedPreferencesBackupHelper(this);
         addHelper("prefs", helper);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -3147,9 +3147,6 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                     if (settings.logout_tokens == null) {
                         settings.logout_tokens = new ArrayList<>();
                     }
-                    if (BuildVars.DEBUG_VERSION) {
-                        FileLog.d("login token to check " + new String(loginTokens.get(i).future_auth_token, StandardCharsets.UTF_8));
-                    }
                     settings.logout_tokens.add(loginTokens.get(i).future_auth_token);
                     if (settings.logout_tokens.size() >= 20) {
                         break;


### PR DESCRIPTION
## Problem

Auth tokens (`future_auth_token`) are logged in plaintext via `FileLog.d()` in debug builds (AuthTokensHelper.java:85, LoginActivity.java:3151). These tokens appear in logcat output and are accessible to any app with READ_LOGS permission or via ADB.

Additionally, `saved_tokens` and `saved_tokens_login` SharedPreferences are registered with `BackupAgent` for automatic cloud backup, meaning unencrypted token data gets synced to Google's backup servers.

## Changes

- Remove plaintext token logging from `saveLogInToken()` and the logout token collection loop
- Disable `BackupAgent.requestBackup()` calls after token saves
- Remove token SharedPreferences from `BackupAgent` backup registration

## Testing

- Verified `FileLog.d` calls with token content no longer present
- Token save/load flow unchanged, only logging and backup side effects removed
- Login and logout token persistence works as before