### PR TITLE
Sanitize theme file names to prevent path traversal

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -6367,6 +6367,11 @@ public class Theme {
             if (!themeName.toLowerCase().endsWith(".attheme")) {
                 themeName += ".attheme";
             }
+            // strip directory separators to prevent path traversal
+            themeName = themeName.replace("/", "").replace("\\", "").replace("..", "");
+            if (themeName.isEmpty()) {
+                return null;
+            }
             if (temporary) {
                 NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.goingToPreviewTheme);
                 ThemeInfo themeInfo = new ThemeInfo();
@@ -6385,6 +6390,12 @@ public class Theme {
                 } else {
                     key = themeName;
                     finalFile = new File(ApplicationLoader.getFilesDirFixed(), key);
+                    // validate the resolved path stays within the app directory
+                    String baseDir = ApplicationLoader.getFilesDirFixed().getCanonicalPath();
+                    if (!finalFile.getCanonicalPath().startsWith(baseDir)) {
+                        FileLog.e("theme file path escapes app directory: " + key);
+                        return null;
+                    }
                 }
                 if (!AndroidUtilities.copyFile(file, finalFile)) {
                     applyPreviousTheme();


### PR DESCRIPTION
## Problem

`applyThemeFile()` in Theme.java constructs file paths using the `themeName` parameter from message attachments and document names without sanitization. A crafted name containing `../` sequences could resolve outside the app data directory.

Entry points include theme files received via messages (ChatActivity), channel admin logs, and deep links.

## Changes

- Strip `/`, `\`, and `..` sequences from theme names before use in file path construction
- Add canonical path validation to confirm the resolved file stays within the app data directory
- Return null early if sanitized name is empty

## Testing

- Normal theme import still works
- File names with path traversal sequences get rejected
- Remote theme installation via theme links unaffected (uses `theme.id` prefix)