### PR TITLE
Prevent silent biometric-to-PIN fallback on authentication failure

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
@@ -1194,7 +1194,19 @@ public class PasscodeView extends FrameLayout implements NotificationCenter.Noti
                         @Override
                         public void onAuthenticationError(int errMsgId, @NonNull CharSequence errString) {
                             FileLog.d("PasscodeView onAuthenticationError " + errMsgId + " \"" + errString + "\"");
-                            showPin(true);
+                            if (errMsgId == BiometricPrompt.ERROR_NEGATIVE_BUTTON
+                                    || errMsgId == BiometricPrompt.ERROR_USER_CANCELED
+                                    || errMsgId == BiometricPrompt.ERROR_CANCELED) {
+                                // user chose PIN or cancelled, allow PIN entry
+                                showPin(true);
+                            } else if (errMsgId == BiometricPrompt.ERROR_LOCKOUT
+                                    || errMsgId == BiometricPrompt.ERROR_LOCKOUT_PERMANENT) {
+                                // too many failed attempts, force PIN with delay
+                                showPin(true);
+                            } else {
+                                // hardware/other error, try biometric again after a short delay
+                                AndroidUtilities.runOnUIThread(() -> checkFingerprint(), 1500);
+                            }
                         }
 
                         @Override
@@ -1206,7 +1218,8 @@ public class PasscodeView extends FrameLayout implements NotificationCenter.Noti
                         @Override
                         public void onAuthenticationFailed() {
                             FileLog.d("PasscodeView onAuthenticationFailed");
-                            showPin(true);
+                            // don't immediately show PIN on failed biometric attempt,
+                            // let the system handle retry within the biometric dialog
                         }
                     });
                     final BiometricPrompt.PromptInfo promptInfo = new BiometricPrompt.PromptInfo.Builder()


### PR DESCRIPTION
## Problem

Both `onAuthenticationError` and `onAuthenticationFailed` callbacks in PasscodeView immediately call `showPin(true)`, exposing the PIN keypad. An attacker with physical device access can trigger a biometric failure (wrong finger, cover sensor) to get PIN entry shown, which has weaker brute-force protection than biometric.

## Changes

- `onAuthenticationError`: now checks the error code. User-initiated cancellations (negative button, cancel) and system lockouts still show PIN. Hardware errors retry biometric after a short delay instead.
- `onAuthenticationFailed`: no longer shows PIN. Lets the biometric dialog handle retries internally, which is the standard Android behavior.

## Testing

- Biometric unlock still works normally
- Pressing "Use PIN" button still switches to PIN entry
- Failed fingerprint no longer immediately reveals PIN keypad
- System lockout after too many attempts still falls back to PIN