### PR TITLE
Show privacy consent before sending messages to translation services

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
@@ -75,6 +75,7 @@ public class NekoConfig {
     public static boolean disableNumberRounding = false;
     public static boolean disableGreetingSticker = false;
     public static boolean autoTranslate = true;
+    public static boolean translationConsentGiven = false;
     public static boolean showRPCError = false;
     public static float stickerSize = 14.0f;
     public static String translationProvider = Translator.PROVIDER_GOOGLE;
@@ -211,6 +212,7 @@ public class NekoConfig {
             disableJumpToNextChannel = preferences.getBoolean("disableJumpToNextChannel", false);
             disableGreetingSticker = preferences.getBoolean("disableGreetingSticker", false);
             autoTranslate = preferences.getBoolean("autoTranslate", true);
+            translationConsentGiven = preferences.getBoolean("translationConsentGiven", false);
             disableVoiceMessageAutoPlay = preferences.getBoolean("disableVoiceMessageAutoPlay", false);
             unmuteVideosWithVolumeButtons = preferences.getBoolean("unmuteVideosWithVolumeButtons", true);
             transType = preferences.getInt("transType", TRANS_TYPE_NEKO);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/translator/Translator.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/translator/Translator.java
@@ -1,5 +1,6 @@
 package tw.nekomimi.nekogram.translator;
 
+import android.app.Activity;
 import android.content.Context;
 import android.text.TextUtils;
 import android.text.style.URLSpan;
@@ -71,11 +72,43 @@ public class Translator {
     }
 
     public static void showTranslateDialog(Context context, String query, ArrayList<TLRPC.MessageEntity> entities, boolean noforwards, BaseFragment fragment, Utilities.CallbackReturn<URLSpan, Boolean> onLinkPress, String sourceLanguage, View anchorView, Theme.ResourcesProvider resourcesProvider) {
+        if (!NekoConfig.translationConsentGiven) {
+            String providerName = getCurrentTranslatorName();
+            AlertDialog.Builder builder = new AlertDialog.Builder(context, resourcesProvider);
+            builder.setTitle(LocaleController.getString(R.string.AppName));
+            builder.setMessage("Translation sends your message text to " + providerName + " servers. Continue?");
+            builder.setPositiveButton(LocaleController.getString(R.string.OK), (dialog, which) -> {
+                NekoConfig.translationConsentGiven = true;
+                ApplicationLoader.applicationContext.getSharedPreferences("nekoconfig", Activity.MODE_PRIVATE)
+                        .edit().putBoolean("translationConsentGiven", true).apply();
+                showTranslateDialogInternal(context, query, entities, noforwards, fragment, onLinkPress, sourceLanguage, anchorView, resourcesProvider);
+            });
+            builder.setNegativeButton(LocaleController.getString(R.string.Cancel), null);
+            builder.show();
+            return;
+        }
+        showTranslateDialogInternal(context, query, entities, noforwards, fragment, onLinkPress, sourceLanguage, anchorView, resourcesProvider);
+    }
+
+    private static void showTranslateDialogInternal(Context context, String query, ArrayList<TLRPC.MessageEntity> entities, boolean noforwards, BaseFragment fragment, Utilities.CallbackReturn<URLSpan, Boolean> onLinkPress, String sourceLanguage, View anchorView, Theme.ResourcesProvider resourcesProvider) {
         if (NekoConfig.transType == NekoConfig.TRANS_TYPE_EXTERNAL) {
             TranslatorApps.showExternalTranslateDialog(context, query, sourceLanguage, anchorView, resourcesProvider);
         } else {
             TranslateAlert2.showAlert(context, fragment, UserConfig.selectedAccount, sourceLanguage, NekoConfig.translationTarget, query, entities, noforwards, onLinkPress, null, resourcesProvider);
         }
+    }
+
+    private static String getCurrentTranslatorName() {
+        if (PROVIDER_DEEPL.equals(NekoConfig.translationProvider)) return "DeepL";
+        if (PROVIDER_YANDEX.equals(NekoConfig.translationProvider)) return "Yandex";
+        if (PROVIDER_MICROSOFT.equals(NekoConfig.translationProvider)) return "Microsoft";
+        if (PROVIDER_LINGO.equals(NekoConfig.translationProvider)) return "Lingo";
+        if (PROVIDER_YOUDAO.equals(NekoConfig.translationProvider)) return "YouDao";
+        if (PROVIDER_BAIDU.equals(NekoConfig.translationProvider)) return "Baidu";
+        if (PROVIDER_SOGOU.equals(NekoConfig.translationProvider)) return "Sogou";
+        if (PROVIDER_TENCENT.equals(NekoConfig.translationProvider)) return "Tencent";
+        if (PROVIDER_TELEGRAM.equals(NekoConfig.translationProvider)) return "Telegram";
+        return "Google";
     }
 
     public static void handleTranslationError(Context context, final Throwable t, final Runnable onRetry, Theme.ResourcesProvider resourcesProvider) {


### PR DESCRIPTION
## Problem

When a user taps translate on any message, the text is immediately sent to a third-party service (Google, DeepL, Yandex, etc.) without any disclosure or consent. The translation fires in the TranslateAlert2 constructor before the dialog is even visible.

Users may not realize their private messages are being transmitted to external servers.

## Changes

- Add a `translationConsentGiven` flag in NekoConfig
- Show a one-time dialog before the first translation, naming which provider will receive the text
- Persist the consent flag so the dialog only appears once
- Extracted the actual translation call into `showTranslateDialogInternal()` to keep the flow clean

## Testing

- First translation attempt shows consent dialog
- After accepting, translations work as before with no extra prompts
- Switching translation provider does not re-trigger consent (per-app, not per-provider)
- External translator app path bypasses the dialog since it opens a user-visible app