### PR TITLE
Log offered server key fingerprints on handshake mismatch

### DIFF
--- a/TMessagesProj/jni/tgnet/Handshake.cpp
+++ b/TMessagesProj/jni/tgnet/Handshake.cpp
@@ -406,7 +406,11 @@ void Handshake::processHandshakeResponse_resPQ(TLObject *message, int64_t messag
                 if (LOGS_ENABLED) DEBUG_D("account%u dc%u handshake: can't find valid cdn server public key, type = %d", currentDatacenter->instanceNum, currentDatacenter->datacenterId, handshakeType);
                 loadCdnConfig(currentDatacenter);
             } else {
-                if (LOGS_ENABLED) DEBUG_E("account%u dc%u handshake: can't find valid server public key, type = %d", currentDatacenter->instanceNum, currentDatacenter->datacenterId, handshakeType);
+                if (LOGS_ENABLED) DEBUG_E("account%u dc%u handshake: can't find valid server public key, type = %d, offered %u fingerprints", currentDatacenter->instanceNum, currentDatacenter->datacenterId, handshakeType, (unsigned int) count1);
+                for (uint32_t a = 0; a < count1; a++) {
+                    if (LOGS_ENABLED) DEBUG_E("  server offered fingerprint[%u]: 0x%llx", a, (unsigned long long) result->server_public_key_fingerprints[a]);
+                }
+                // do not retry immediately to avoid tight loops on key mismatch
                 beginHandshake(false);
             }
             return;


### PR DESCRIPTION
## Problem

When the MTProto handshake fails due to server key fingerprint mismatch, the error log only says the key was not found. There is no way to know which fingerprints the server actually offered, making it difficult to diagnose key rotation issues or detect MITM attempts.

## Changes

- Log the count of offered fingerprints and iterate over all of them, printing each as hex
- Preserves existing behavior of restarting the handshake on mismatch

This makes key rotation events visible in the logs so developers can update pinned keys proactively.

## Testing

- Normal handshake path unchanged (fingerprint matches on first try)
- On simulated mismatch, all offered fingerprints appear in debug output