### PR TITLE
Require user confirmation before accepting QR code login

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -3161,21 +3161,28 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
             } else if (scanQr) {
                 ActionIntroActivity fragment = new ActionIntroActivity(ActionIntroActivity.ACTION_TYPE_QR_LOGIN);
                 fragment.setQrLoginDelegate(code -> {
-                    AlertDialog progressDialog = new AlertDialog(LaunchActivity.this, AlertDialog.ALERT_TYPE_SPINNER);
-                    progressDialog.setCanCancel(false);
-                    progressDialog.show();
-                    byte[] token = Base64.decode(code.substring("tg://login?token=".length()), Base64.URL_SAFE);
-                    TLRPC.TL_auth_acceptLoginToken req = new TLRPC.TL_auth_acceptLoginToken();
-                    req.token = token;
-                    ConnectionsManager.getInstance(currentAccount).sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
-                        try {
-                            progressDialog.dismiss();
-                        } catch (Exception ignore) {
-                        }
-                        if (!(response instanceof TLRPC.TL_authorization)) {
-                            AndroidUtilities.runOnUIThread(() -> AlertsCreator.showSimpleAlert(fragment, LocaleController.getString(R.string.AuthAnotherClient), LocaleController.getString(R.string.ErrorOccurred) + "\n" + error.text));
-                        }
-                    }));
+                    AlertDialog.Builder confirmBuilder = new AlertDialog.Builder(LaunchActivity.this);
+                    confirmBuilder.setTitle(LocaleController.getString(R.string.AuthAnotherClient));
+                    confirmBuilder.setMessage(LocaleController.getString(R.string.AuthAnotherClientInfo));
+                    confirmBuilder.setPositiveButton(LocaleController.getString(R.string.OK), (dlg, which) -> {
+                        AlertDialog progressDialog = new AlertDialog(LaunchActivity.this, AlertDialog.ALERT_TYPE_SPINNER);
+                        progressDialog.setCanCancel(false);
+                        progressDialog.show();
+                        byte[] token = Base64.decode(code.substring("tg://login?token=".length()), Base64.URL_SAFE);
+                        TLRPC.TL_auth_acceptLoginToken req = new TLRPC.TL_auth_acceptLoginToken();
+                        req.token = token;
+                        ConnectionsManager.getInstance(currentAccount).sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
+                            try {
+                                progressDialog.dismiss();
+                            } catch (Exception ignore) {
+                            }
+                            if (!(response instanceof TLRPC.TL_authorization)) {
+                                AndroidUtilities.runOnUIThread(() -> AlertsCreator.showSimpleAlert(fragment, LocaleController.getString(R.string.AuthAnotherClient), LocaleController.getString(R.string.ErrorOccurred) + "\n" + error.text));
+                            }
+                        }));
+                    });
+                    confirmBuilder.setNegativeButton(LocaleController.getString(R.string.Cancel), null);
+                    confirmBuilder.show();
                 });
                 getActionBarLayout().presentFragment(new INavigationLayout.NavigationParams(fragment).setNoAnimation(true));
                 if (AndroidUtilities.isTablet()) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/SessionsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SessionsActivity.java
@@ -1154,25 +1154,32 @@ public class SessionsActivity extends BaseFragment implements NotificationCenter
                 this.response = null;
                 this.error = null;
                 AndroidUtilities.runOnUIThread(() -> {
-                    try {
-                        String code = link.substring("tg://login?token=".length());
-                        code = code.replaceAll("\\/", "_");
-                        code = code.replaceAll("\\+", "-");
-                        byte[] token = Base64.decode(code, Base64.URL_SAFE);
-                        TLRPC.TL_auth_acceptLoginToken req = new TLRPC.TL_auth_acceptLoginToken();
-                        req.token = token;
-                        getConnectionsManager().sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
-                            this.response = response;
-                            this.error = error;
+                    AlertDialog.Builder confirmBuilder = new AlertDialog.Builder(getParentActivity());
+                    confirmBuilder.setTitle(LocaleController.getString(R.string.AuthAnotherClient));
+                    confirmBuilder.setMessage(LocaleController.getString(R.string.AuthAnotherClientInfo));
+                    confirmBuilder.setPositiveButton(LocaleController.getString(R.string.OK), (dlg, which) -> {
+                        try {
+                            String code = link.substring("tg://login?token=".length());
+                            code = code.replaceAll("\\/", "_");
+                            code = code.replaceAll("\\+", "-");
+                            byte[] token = Base64.decode(code, Base64.URL_SAFE);
+                            TLRPC.TL_auth_acceptLoginToken req = new TLRPC.TL_auth_acceptLoginToken();
+                            req.token = token;
+                            getConnectionsManager().sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
+                                this.response = response;
+                                this.error = error;
+                                onLoadEnd.run();
+                            }));
+                        } catch (Exception e) {
+                            FileLog.e("Failed to pass qr code auth", e);
+                            AndroidUtilities.runOnUIThread(() -> {
+                                AlertsCreator.showSimpleAlert(SessionsActivity.this, LocaleController.getString(R.string.AuthAnotherClient), LocaleController.getString(R.string.ErrorOccurred));
+                            });
                             onLoadEnd.run();
-                        }));
-                    } catch (Exception e) {
-                        FileLog.e("Failed to pass qr code auth", e);
-                        AndroidUtilities.runOnUIThread(() -> {
-                            AlertsCreator.showSimpleAlert(SessionsActivity.this, LocaleController.getString(R.string.AuthAnotherClient), LocaleController.getString(R.string.ErrorOccurred));
-                        });
-                        onLoadEnd.run();
-                    }
+                        }
+                    });
+                    confirmBuilder.setNegativeButton(LocaleController.getString(R.string.Cancel), (dlg, which) -> onLoadEnd.run());
+                    confirmBuilder.show();
                 }, 750);
                 return true;
             }


### PR DESCRIPTION
## Problem

When scanning a QR code for session login, the token is accepted and sent to the server immediately without any user confirmation. If an attacker captures or screenshots a QR code, they have a window to hijack the session. The current flow also does not give the user a chance to reconsider after scanning.

Both LaunchActivity and SessionsActivity accept QR tokens without confirmation.

## Changes

- Wrap the token acceptance in both `LaunchActivity.setQrLoginDelegate` and `SessionsActivity.processQr` with an AlertDialog asking the user to confirm
- Use existing localization strings (`AuthAnotherClient`, `AuthAnotherClientInfo`) for the dialog text
- Cancel button aborts the login flow cleanly

## Testing

- QR code scan now shows confirmation dialog before authorizing
- Pressing OK proceeds with login as before
- Pressing Cancel aborts without sending the token
- SessionsActivity QR flow also shows confirmation