### PR TITLE
Encrypt proxy credentials at rest using Android KeyStore

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
@@ -39,6 +39,13 @@ import org.telegram.ui.LaunchActivity;
 import java.io.File;
 import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
+import java.security.KeyStore;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.URLEncoder;
@@ -1423,6 +1430,66 @@ public class SharedConfig {
         LocaleController.resetImperialSystemType();
     }
 
+    private static final String PROXY_KEY_ALIAS = "nekogram_proxy_key";
+
+    private static byte[] encryptProxyData(byte[] data) {
+        try {
+            if (Build.VERSION.SDK_INT >= 23) {
+                KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+                keyStore.load(null);
+                if (!keyStore.containsAlias(PROXY_KEY_ALIAS)) {
+                    KeyGenerator keyGen = KeyGenerator.getInstance(
+                            KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore");
+                    keyGen.init(new KeyGenParameterSpec.Builder(
+                            PROXY_KEY_ALIAS,
+                            KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                            .build());
+                    keyGen.generateKey();
+                }
+                SecretKey key = (SecretKey) keyStore.getKey(PROXY_KEY_ALIAS, null);
+                Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+                cipher.init(Cipher.ENCRYPT_MODE, key);
+                byte[] iv = cipher.getIV();
+                byte[] encrypted = cipher.doFinal(data);
+                byte[] result = new byte[1 + iv.length + encrypted.length];
+                result[0] = (byte) iv.length;
+                System.arraycopy(iv, 0, result, 1, iv.length);
+                System.arraycopy(encrypted, 0, result, 1 + iv.length, encrypted.length);
+                return result;
+            }
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+        return data;
+    }
+
+    private static byte[] decryptProxyData(byte[] data) {
+        try {
+            if (Build.VERSION.SDK_INT >= 23 && data.length > 1) {
+                KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+                keyStore.load(null);
+                if (keyStore.containsAlias(PROXY_KEY_ALIAS)) {
+                    int ivLen = data[0] & 0xFF;
+                    if (ivLen > 0 && ivLen < data.length - 1) {
+                        byte[] iv = new byte[ivLen];
+                        System.arraycopy(data, 1, iv, 0, ivLen);
+                        byte[] encrypted = new byte[data.length - 1 - ivLen];
+                        System.arraycopy(data, 1 + ivLen, encrypted, 0, encrypted.length);
+                        SecretKey key = (SecretKey) keyStore.getKey(PROXY_KEY_ALIAS, null);
+                        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+                        cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, iv));
+                        return cipher.doFinal(encrypted);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+        return data;
+    }
+
     public static void loadProxyList() {
         if (proxyListLoaded) {
             return;
@@ -1439,7 +1506,7 @@ public class SharedConfig {
         currentProxy = null;
         String list = preferences.getString("proxy_list", null);
         if (!TextUtils.isEmpty(list)) {
-            byte[] bytes = Base64.decode(list, Base64.DEFAULT);
+            byte[] bytes = decryptProxyData(Base64.decode(list, Base64.DEFAULT));
             SerializedData data = new SerializedData(bytes);
             int count = data.readInt32(false);
             if (count == -1) { // V2 or newer
@@ -1523,7 +1590,7 @@ public class SharedConfig {
             serializedData.writeInt64(info.availableCheckTime);
         }
         SharedPreferences preferences = ApplicationLoader.applicationContext.getSharedPreferences("mainconfig", Activity.MODE_PRIVATE);
-        preferences.edit().putString("proxy_list", Base64.encodeToString(serializedData.toByteArray(), Base64.NO_WRAP)).apply();
+        preferences.edit().putString("proxy_list", Base64.encodeToString(encryptProxyData(serializedData.toByteArray()), Base64.NO_WRAP)).apply();
         serializedData.cleanup();
     }
 


### PR DESCRIPTION
## Problem

Proxy server addresses, usernames, passwords, and MTProto secrets are stored in SharedPreferences as a Base64-encoded blob. Base64 is trivially reversible and provides no confidentiality. Any app or backup process with access to the shared_prefs directory can extract proxy credentials.

## Changes

- Add AES-GCM encryption using a hardware-backed key from Android KeyStore before writing the proxy list to SharedPreferences
- Decrypt on load with transparent fallback for unencrypted data (handles migration from existing installations)
- Gracefully skip encryption on pre-Marshmallow devices where KeyStore AES is not available
- IV is prepended to the ciphertext blob so each save uses a fresh nonce

## Testing

- Proxy list save/load works on API 23+ with encrypted storage
- Pre-M devices continue to use Base64 (no crash)
- Existing unencrypted proxy lists are read successfully on first launch after update
- Proxy add, remove, and switch operations work as before