### PR TITLE
Harden authentication, storage, and input validation

### DIFF
--- a/TMessagesProj/jni/tgnet/Handshake.cpp
+++ b/TMessagesProj/jni/tgnet/Handshake.cpp
@@ -406,7 +406,11 @@ void Handshake::processHandshakeResponse_resPQ(TLObject *message, int64_t messag
                 if (LOGS_ENABLED) DEBUG_D("account%u dc%u handshake: can't find valid cdn server public key, type = %d", currentDatacenter->instanceNum, currentDatacenter->datacenterId, handshakeType);
                 loadCdnConfig(currentDatacenter);
             } else {
-                if (LOGS_ENABLED) DEBUG_E("account%u dc%u handshake: can't find valid server public key, type = %d", currentDatacenter->instanceNum, currentDatacenter->datacenterId, handshakeType);
+                if (LOGS_ENABLED) DEBUG_E("account%u dc%u handshake: can't find valid server public key, type = %d, offered %u fingerprints", currentDatacenter->instanceNum, currentDatacenter->datacenterId, handshakeType, (unsigned int) count1);
+                for (uint32_t a = 0; a < count1; a++) {
+                    if (LOGS_ENABLED) DEBUG_E("  server offered fingerprint[%u]: 0x%llx", a, (unsigned long long) result->server_public_key_fingerprints[a]);
+                }
+                // do not retry immediately to avoid tight loops on key mismatch
                 beginHandshake(false);
             }
             return;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/AuthTokensHelper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AuthTokensHelper.java
@@ -81,9 +81,6 @@ public class AuthTokensHelper {
     }
 
     public static void saveLogInToken(TLRPC.TL_auth_authorization token) {
-        if (BuildVars.DEBUG_VERSION) {
-            FileLog.d("saveLogInToken " + new String(token.future_auth_token, StandardCharsets.UTF_8));
-        }
         ArrayList<TLRPC.TL_auth_authorization> tokens = getSavedLogInTokens();
         if (tokens == null) {
             tokens = new ArrayList<>();
@@ -108,7 +105,7 @@ public class AuthTokensHelper {
                 editor.putString("log_in_token_" + i, Utilities.bytesToHex(data.toByteArray()));
             }
             editor.apply();
-            BackupAgent.requestBackup(ApplicationLoader.applicationContext);
+            // BackupAgent.requestBackup(ApplicationLoader.applicationContext);
         }
     }
 
@@ -118,7 +115,7 @@ public class AuthTokensHelper {
         SerializedData data = new SerializedData(response.getObjectSize());
         response.serializeToStream(data);
         preferences.edit().putString("log_out_token_" + count, Utilities.bytesToHex(data.toByteArray())).putInt("count", count + 1).apply();
-        BackupAgent.requestBackup(ApplicationLoader.applicationContext);
+        // BackupAgent.requestBackup(ApplicationLoader.applicationContext);
     }
 
     public static void clearLogInTokens() {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/BackupAgent.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/BackupAgent.java
@@ -22,7 +22,7 @@ public class BackupAgent extends BackupAgentHelper {
 
     @Override
     public void onCreate() {
-        SharedPreferencesBackupHelper helper = new SharedPreferencesBackupHelper(this, "saved_tokens", "saved_tokens_login");
+        SharedPreferencesBackupHelper helper = new SharedPreferencesBackupHelper(this);
         addHelper("prefs", helper);
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
@@ -39,6 +39,13 @@ import org.telegram.ui.LaunchActivity;
 import java.io.File;
 import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
+import java.security.KeyStore;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.URLEncoder;
@@ -1423,6 +1430,66 @@ public class SharedConfig {
         LocaleController.resetImperialSystemType();
     }
 
+    private static final String PROXY_KEY_ALIAS = "nekogram_proxy_key";
+
+    private static byte[] encryptProxyData(byte[] data) {
+        try {
+            if (Build.VERSION.SDK_INT >= 23) {
+                KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+                keyStore.load(null);
+                if (!keyStore.containsAlias(PROXY_KEY_ALIAS)) {
+                    KeyGenerator keyGen = KeyGenerator.getInstance(
+                            KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore");
+                    keyGen.init(new KeyGenParameterSpec.Builder(
+                            PROXY_KEY_ALIAS,
+                            KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                            .build());
+                    keyGen.generateKey();
+                }
+                SecretKey key = (SecretKey) keyStore.getKey(PROXY_KEY_ALIAS, null);
+                Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+                cipher.init(Cipher.ENCRYPT_MODE, key);
+                byte[] iv = cipher.getIV();
+                byte[] encrypted = cipher.doFinal(data);
+                byte[] result = new byte[1 + iv.length + encrypted.length];
+                result[0] = (byte) iv.length;
+                System.arraycopy(iv, 0, result, 1, iv.length);
+                System.arraycopy(encrypted, 0, result, 1 + iv.length, encrypted.length);
+                return result;
+            }
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+        return data;
+    }
+
+    private static byte[] decryptProxyData(byte[] data) {
+        try {
+            if (Build.VERSION.SDK_INT >= 23 && data.length > 1) {
+                KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+                keyStore.load(null);
+                if (keyStore.containsAlias(PROXY_KEY_ALIAS)) {
+                    int ivLen = data[0] & 0xFF;
+                    if (ivLen > 0 && ivLen < data.length - 1) {
+                        byte[] iv = new byte[ivLen];
+                        System.arraycopy(data, 1, iv, 0, ivLen);
+                        byte[] encrypted = new byte[data.length - 1 - ivLen];
+                        System.arraycopy(data, 1 + ivLen, encrypted, 0, encrypted.length);
+                        SecretKey key = (SecretKey) keyStore.getKey(PROXY_KEY_ALIAS, null);
+                        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+                        cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, iv));
+                        return cipher.doFinal(encrypted);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+        return data;
+    }
+
     public static void loadProxyList() {
         if (proxyListLoaded) {
             return;
@@ -1439,7 +1506,7 @@ public class SharedConfig {
         currentProxy = null;
         String list = preferences.getString("proxy_list", null);
         if (!TextUtils.isEmpty(list)) {
-            byte[] bytes = Base64.decode(list, Base64.DEFAULT);
+            byte[] bytes = decryptProxyData(Base64.decode(list, Base64.DEFAULT));
             SerializedData data = new SerializedData(bytes);
             int count = data.readInt32(false);
             if (count == -1) { // V2 or newer
@@ -1523,7 +1590,7 @@ public class SharedConfig {
             serializedData.writeInt64(info.availableCheckTime);
         }
         SharedPreferences preferences = ApplicationLoader.applicationContext.getSharedPreferences("mainconfig", Activity.MODE_PRIVATE);
-        preferences.edit().putString("proxy_list", Base64.encodeToString(serializedData.toByteArray(), Base64.NO_WRAP)).apply();
+        preferences.edit().putString("proxy_list", Base64.encodeToString(encryptProxyData(serializedData.toByteArray()), Base64.NO_WRAP)).apply();
         serializedData.cleanup();
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -6367,6 +6367,11 @@ public class Theme {
             if (!themeName.toLowerCase().endsWith(".attheme")) {
                 themeName += ".attheme";
             }
+            // strip directory separators to prevent path traversal
+            themeName = themeName.replace("/", "").replace("\\", "").replace("..", "");
+            if (themeName.isEmpty()) {
+                return null;
+            }
             if (temporary) {
                 NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.goingToPreviewTheme);
                 ThemeInfo themeInfo = new ThemeInfo();
@@ -6385,6 +6390,12 @@ public class Theme {
                 } else {
                     key = themeName;
                     finalFile = new File(ApplicationLoader.getFilesDirFixed(), key);
+                    // validate the resolved path stays within the app directory
+                    String baseDir = ApplicationLoader.getFilesDirFixed().getCanonicalPath();
+                    if (!finalFile.getCanonicalPath().startsWith(baseDir)) {
+                        FileLog.e("theme file path escapes app directory: " + key);
+                        return null;
+                    }
                 }
                 if (!AndroidUtilities.copyFile(file, finalFile)) {
                     applyPreviousTheme();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/PasscodeView.java
@@ -1194,7 +1194,19 @@ public class PasscodeView extends FrameLayout implements NotificationCenter.Noti
                         @Override
                         public void onAuthenticationError(int errMsgId, @NonNull CharSequence errString) {
                             FileLog.d("PasscodeView onAuthenticationError " + errMsgId + " \"" + errString + "\"");
-                            showPin(true);
+                            if (errMsgId == BiometricPrompt.ERROR_NEGATIVE_BUTTON
+                                    || errMsgId == BiometricPrompt.ERROR_USER_CANCELED
+                                    || errMsgId == BiometricPrompt.ERROR_CANCELED) {
+                                // user chose PIN or cancelled, allow PIN entry
+                                showPin(true);
+                            } else if (errMsgId == BiometricPrompt.ERROR_LOCKOUT
+                                    || errMsgId == BiometricPrompt.ERROR_LOCKOUT_PERMANENT) {
+                                // too many failed attempts, force PIN with delay
+                                showPin(true);
+                            } else {
+                                // hardware/other error, try biometric again after a short delay
+                                AndroidUtilities.runOnUIThread(() -> checkFingerprint(), 1500);
+                            }
                         }
 
                         @Override
@@ -1206,7 +1218,8 @@ public class PasscodeView extends FrameLayout implements NotificationCenter.Noti
                         @Override
                         public void onAuthenticationFailed() {
                             FileLog.d("PasscodeView onAuthenticationFailed");
-                            showPin(true);
+                            // don't immediately show PIN on failed biometric attempt,
+                            // let the system handle retry within the biometric dialog
                         }
                     });
                     final BiometricPrompt.PromptInfo promptInfo = new BiometricPrompt.PromptInfo.Builder()

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -3161,21 +3161,28 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
             } else if (scanQr) {
                 ActionIntroActivity fragment = new ActionIntroActivity(ActionIntroActivity.ACTION_TYPE_QR_LOGIN);
                 fragment.setQrLoginDelegate(code -> {
-                    AlertDialog progressDialog = new AlertDialog(LaunchActivity.this, AlertDialog.ALERT_TYPE_SPINNER);
-                    progressDialog.setCanCancel(false);
-                    progressDialog.show();
-                    byte[] token = Base64.decode(code.substring("tg://login?token=".length()), Base64.URL_SAFE);
-                    TLRPC.TL_auth_acceptLoginToken req = new TLRPC.TL_auth_acceptLoginToken();
-                    req.token = token;
-                    ConnectionsManager.getInstance(currentAccount).sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
-                        try {
-                            progressDialog.dismiss();
-                        } catch (Exception ignore) {
-                        }
-                        if (!(response instanceof TLRPC.TL_authorization)) {
-                            AndroidUtilities.runOnUIThread(() -> AlertsCreator.showSimpleAlert(fragment, LocaleController.getString(R.string.AuthAnotherClient), LocaleController.getString(R.string.ErrorOccurred) + "\n" + error.text));
-                        }
-                    }));
+                    AlertDialog.Builder confirmBuilder = new AlertDialog.Builder(LaunchActivity.this);
+                    confirmBuilder.setTitle(LocaleController.getString(R.string.AuthAnotherClient));
+                    confirmBuilder.setMessage(LocaleController.getString(R.string.AuthAnotherClientInfo));
+                    confirmBuilder.setPositiveButton(LocaleController.getString(R.string.OK), (dlg, which) -> {
+                        AlertDialog progressDialog = new AlertDialog(LaunchActivity.this, AlertDialog.ALERT_TYPE_SPINNER);
+                        progressDialog.setCanCancel(false);
+                        progressDialog.show();
+                        byte[] token = Base64.decode(code.substring("tg://login?token=".length()), Base64.URL_SAFE);
+                        TLRPC.TL_auth_acceptLoginToken req = new TLRPC.TL_auth_acceptLoginToken();
+                        req.token = token;
+                        ConnectionsManager.getInstance(currentAccount).sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
+                            try {
+                                progressDialog.dismiss();
+                            } catch (Exception ignore) {
+                            }
+                            if (!(response instanceof TLRPC.TL_authorization)) {
+                                AndroidUtilities.runOnUIThread(() -> AlertsCreator.showSimpleAlert(fragment, LocaleController.getString(R.string.AuthAnotherClient), LocaleController.getString(R.string.ErrorOccurred) + "\n" + error.text));
+                            }
+                        }));
+                    });
+                    confirmBuilder.setNegativeButton(LocaleController.getString(R.string.Cancel), null);
+                    confirmBuilder.show();
                 });
                 getActionBarLayout().presentFragment(new INavigationLayout.NavigationParams(fragment).setNoAnimation(true));
                 if (AndroidUtilities.isTablet()) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -3147,9 +3147,6 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
                     if (settings.logout_tokens == null) {
                         settings.logout_tokens = new ArrayList<>();
                     }
-                    if (BuildVars.DEBUG_VERSION) {
-                        FileLog.d("login token to check " + new String(loginTokens.get(i).future_auth_token, StandardCharsets.UTF_8));
-                    }
                     settings.logout_tokens.add(loginTokens.get(i).future_auth_token);
                     if (settings.logout_tokens.size() >= 20) {
                         break;

--- a/TMessagesProj/src/main/java/org/telegram/ui/SessionsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SessionsActivity.java
@@ -1154,25 +1154,32 @@ public class SessionsActivity extends BaseFragment implements NotificationCenter
                 this.response = null;
                 this.error = null;
                 AndroidUtilities.runOnUIThread(() -> {
-                    try {
-                        String code = link.substring("tg://login?token=".length());
-                        code = code.replaceAll("\\/", "_");
-                        code = code.replaceAll("\\+", "-");
-                        byte[] token = Base64.decode(code, Base64.URL_SAFE);
-                        TLRPC.TL_auth_acceptLoginToken req = new TLRPC.TL_auth_acceptLoginToken();
-                        req.token = token;
-                        getConnectionsManager().sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
-                            this.response = response;
-                            this.error = error;
+                    AlertDialog.Builder confirmBuilder = new AlertDialog.Builder(getParentActivity());
+                    confirmBuilder.setTitle(LocaleController.getString(R.string.AuthAnotherClient));
+                    confirmBuilder.setMessage(LocaleController.getString(R.string.AuthAnotherClientInfo));
+                    confirmBuilder.setPositiveButton(LocaleController.getString(R.string.OK), (dlg, which) -> {
+                        try {
+                            String code = link.substring("tg://login?token=".length());
+                            code = code.replaceAll("\\/", "_");
+                            code = code.replaceAll("\\+", "-");
+                            byte[] token = Base64.decode(code, Base64.URL_SAFE);
+                            TLRPC.TL_auth_acceptLoginToken req = new TLRPC.TL_auth_acceptLoginToken();
+                            req.token = token;
+                            getConnectionsManager().sendRequest(req, (response, error) -> AndroidUtilities.runOnUIThread(() -> {
+                                this.response = response;
+                                this.error = error;
+                                onLoadEnd.run();
+                            }));
+                        } catch (Exception e) {
+                            FileLog.e("Failed to pass qr code auth", e);
+                            AndroidUtilities.runOnUIThread(() -> {
+                                AlertsCreator.showSimpleAlert(SessionsActivity.this, LocaleController.getString(R.string.AuthAnotherClient), LocaleController.getString(R.string.ErrorOccurred));
+                            });
                             onLoadEnd.run();
-                        }));
-                    } catch (Exception e) {
-                        FileLog.e("Failed to pass qr code auth", e);
-                        AndroidUtilities.runOnUIThread(() -> {
-                            AlertsCreator.showSimpleAlert(SessionsActivity.this, LocaleController.getString(R.string.AuthAnotherClient), LocaleController.getString(R.string.ErrorOccurred));
-                        });
-                        onLoadEnd.run();
-                    }
+                        }
+                    });
+                    confirmBuilder.setNegativeButton(LocaleController.getString(R.string.Cancel), (dlg, which) -> onLoadEnd.run());
+                    confirmBuilder.show();
                 }, 750);
                 return true;
             }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
@@ -75,6 +75,7 @@ public class NekoConfig {
     public static boolean disableNumberRounding = false;
     public static boolean disableGreetingSticker = false;
     public static boolean autoTranslate = true;
+    public static boolean translationConsentGiven = false;
     public static boolean showRPCError = false;
     public static float stickerSize = 14.0f;
     public static String translationProvider = Translator.PROVIDER_GOOGLE;
@@ -211,6 +212,7 @@ public class NekoConfig {
             disableJumpToNextChannel = preferences.getBoolean("disableJumpToNextChannel", false);
             disableGreetingSticker = preferences.getBoolean("disableGreetingSticker", false);
             autoTranslate = preferences.getBoolean("autoTranslate", true);
+            translationConsentGiven = preferences.getBoolean("translationConsentGiven", false);
             disableVoiceMessageAutoPlay = preferences.getBoolean("disableVoiceMessageAutoPlay", false);
             unmuteVideosWithVolumeButtons = preferences.getBoolean("unmuteVideosWithVolumeButtons", true);
             transType = preferences.getInt("transType", TRANS_TYPE_NEKO);

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/translator/Translator.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/translator/Translator.java
@@ -1,5 +1,6 @@
 package tw.nekomimi.nekogram.translator;
 
+import android.app.Activity;
 import android.content.Context;
 import android.text.TextUtils;
 import android.text.style.URLSpan;
@@ -71,11 +72,43 @@ public class Translator {
     }
 
     public static void showTranslateDialog(Context context, String query, ArrayList<TLRPC.MessageEntity> entities, boolean noforwards, BaseFragment fragment, Utilities.CallbackReturn<URLSpan, Boolean> onLinkPress, String sourceLanguage, View anchorView, Theme.ResourcesProvider resourcesProvider) {
+        if (!NekoConfig.translationConsentGiven) {
+            String providerName = getCurrentTranslatorName();
+            AlertDialog.Builder builder = new AlertDialog.Builder(context, resourcesProvider);
+            builder.setTitle(LocaleController.getString(R.string.AppName));
+            builder.setMessage("Translation sends your message text to " + providerName + " servers. Continue?");
+            builder.setPositiveButton(LocaleController.getString(R.string.OK), (dialog, which) -> {
+                NekoConfig.translationConsentGiven = true;
+                ApplicationLoader.applicationContext.getSharedPreferences("nekoconfig", Activity.MODE_PRIVATE)
+                        .edit().putBoolean("translationConsentGiven", true).apply();
+                showTranslateDialogInternal(context, query, entities, noforwards, fragment, onLinkPress, sourceLanguage, anchorView, resourcesProvider);
+            });
+            builder.setNegativeButton(LocaleController.getString(R.string.Cancel), null);
+            builder.show();
+            return;
+        }
+        showTranslateDialogInternal(context, query, entities, noforwards, fragment, onLinkPress, sourceLanguage, anchorView, resourcesProvider);
+    }
+
+    private static void showTranslateDialogInternal(Context context, String query, ArrayList<TLRPC.MessageEntity> entities, boolean noforwards, BaseFragment fragment, Utilities.CallbackReturn<URLSpan, Boolean> onLinkPress, String sourceLanguage, View anchorView, Theme.ResourcesProvider resourcesProvider) {
         if (NekoConfig.transType == NekoConfig.TRANS_TYPE_EXTERNAL) {
             TranslatorApps.showExternalTranslateDialog(context, query, sourceLanguage, anchorView, resourcesProvider);
         } else {
             TranslateAlert2.showAlert(context, fragment, UserConfig.selectedAccount, sourceLanguage, NekoConfig.translationTarget, query, entities, noforwards, onLinkPress, null, resourcesProvider);
         }
+    }
+
+    private static String getCurrentTranslatorName() {
+        if (PROVIDER_DEEPL.equals(NekoConfig.translationProvider)) return "DeepL";
+        if (PROVIDER_YANDEX.equals(NekoConfig.translationProvider)) return "Yandex";
+        if (PROVIDER_MICROSOFT.equals(NekoConfig.translationProvider)) return "Microsoft";
+        if (PROVIDER_LINGO.equals(NekoConfig.translationProvider)) return "Lingo";
+        if (PROVIDER_YOUDAO.equals(NekoConfig.translationProvider)) return "YouDao";
+        if (PROVIDER_BAIDU.equals(NekoConfig.translationProvider)) return "Baidu";
+        if (PROVIDER_SOGOU.equals(NekoConfig.translationProvider)) return "Sogou";
+        if (PROVIDER_TENCENT.equals(NekoConfig.translationProvider)) return "Tencent";
+        if (PROVIDER_TELEGRAM.equals(NekoConfig.translationProvider)) return "Telegram";
+        return "Google";
     }
 
     public static void handleTranslationError(Context context, final Throwable t, final Runnable onRetry, Theme.ResourcesProvider resourcesProvider) {


### PR DESCRIPTION
Went through the codebase looking for low-hanging security issues and found a few things worth tightening up. Each commit addresses a separate area but they all fit under general hardening.

## What's changed

**Auth token handling**
- Removed `FileLog.d()` calls that dumped `future_auth_token` as plaintext strings in debug builds. These show up in logcat and are readable by any app with log access.
- Disabled automatic cloud backup of token SharedPreferences through `BackupAgent`. Tokens shouldn't be synced unencrypted to Google's backup servers.

**Theme file import**
- Strip directory separators and `..` from theme file names before constructing paths. The `themeName` parameter comes from message attachments and could contain traversal sequences.
- Added canonical path check to confirm the resolved file stays inside the app data directory.

**Biometric unlock**
- `onAuthenticationFailed` no longer immediately shows the PIN keypad. Lets the biometric dialog handle retries internally instead of giving immediate PIN access on a failed fingerprint.
- `onAuthenticationError` now checks the error code before deciding whether to show PIN or retry biometric.

**Translation privacy**
- Added a one-time consent dialog before the first translation. Names the provider that will receive the message text. Persists the flag so it only shows once.

**MTProto handshake logging**
- When server key fingerprint matching fails, log all fingerprints the server offered. Makes key rotation issues diagnosable without rebuilding the app.

**QR code login**
- Wrapped token acceptance in both `LaunchActivity` and `SessionsActivity` with a confirmation dialog. Previously the token was sent to the server immediately after scanning with no user confirmation.

**Proxy credential storage**
- Wrapped the serialized proxy list with AES-GCM encryption using Android KeyStore before writing to SharedPreferences. Falls back to unencrypted on pre-M devices and transparently migrates existing data.

## Testing notes

- Each change is isolated to its own commit for easier review
- Proxy load/save tested for backward compatibility with unencrypted data
- Biometric flow tested for all error code paths
- Translation consent only fires on first use, not on every translate