### PR TITLE
Upload per-ABI APK artifacts in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,3 +105,33 @@ jobs:
         with:
           name: outputs
           path: TMessagesProj_App/build/outputs
+
+      - name: Upload arm64-v8a build apk
+        uses: actions/upload-artifact@v7
+        with:
+          path: TMessagesProj_App/build/outputs/apk/release/*-arm64-v8a.apk
+          archive: false
+
+      - name: Upload armeabi-v7a build apk
+        uses: actions/upload-artifact@v7
+        with:
+          path: TMessagesProj_App/build/outputs/apk/release/*-armeabi-v7a.apk
+          archive: false
+
+      - name: Upload universal build apk
+        uses: actions/upload-artifact@v7
+        with:
+          path: TMessagesProj_App/build/outputs/apk/release/*-universal.apk
+          archive: false
+
+      - name: Upload x86 build apk
+        uses: actions/upload-artifact@v7
+        with:
+          path: TMessagesProj_App/build/outputs/apk/release/*-x86.apk
+          archive: false
+
+      - name: Upload x86_64 build apk
+        uses: actions/upload-artifact@v7
+        with:
+          path: TMessagesProj_App/build/outputs/apk/release/*-x86_64.apk
+          archive: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,30 +107,35 @@ jobs:
           path: TMessagesProj_App/build/outputs
 
       - name: Upload arm64-v8a build apk
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           path: TMessagesProj_App/build/outputs/apk/release/*-arm64-v8a.apk
           archive: false
 
       - name: Upload armeabi-v7a build apk
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           path: TMessagesProj_App/build/outputs/apk/release/*-armeabi-v7a.apk
           archive: false
 
       - name: Upload universal build apk
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           path: TMessagesProj_App/build/outputs/apk/release/*-universal.apk
           archive: false
 
       - name: Upload x86 build apk
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           path: TMessagesProj_App/build/outputs/apk/release/*-x86.apk
           archive: false
 
       - name: Upload x86_64 build apk
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           path: TMessagesProj_App/build/outputs/apk/release/*-x86_64.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,3 +140,10 @@ jobs:
         with:
           path: TMessagesProj_App/build/outputs/apk/release/*-x86_64.apk
           archive: false
+
+      - name: Upload build bundle
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          path: TMessagesProj_App/build/outputs/bundle/play/*-play.aab
+          archive: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8
+        with:
+          name: outputs
 
       - name: Display downloaded files
         run: ls -R


### PR DESCRIPTION
Following this PR, you can install https://nightly.link to provide direct downloads in the readme.md file.