### PR TITLE
Fix highlight position in Neko Settings

### DIFF
--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/BaseNekoSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/BaseNekoSettingsActivity.java
@@ -369,10 +369,16 @@ public abstract class BaseNekoSettingsActivity extends BaseFragment {
         if (listView == null) return;
         var position = listView.findPositionByItemSlug(key);
         if (position != -1) {
-            listView.highlightRow(() -> {
-                var layoutManager = (LinearLayoutManager) listView.getLayoutManager();
-                layoutManager.scrollToPositionWithOffset(position, AndroidUtilities.dp(60));
-                return position;
+            var layoutManager = (LinearLayoutManager) listView.getLayoutManager();
+            layoutManager.scrollToPositionWithOffset(position, AndroidUtilities.dp(60));
+            listView.post(() -> {
+                if (listView == null) return;
+                var currentPosition = listView.findPositionByItemSlug(key);
+                if (currentPosition != -1) {
+                    listView.highlightRow(() -> currentPosition);
+                } else {
+                    unknown.run();
+                }
             });
         } else {
             unknown.run();


### PR DESCRIPTION
The settings-search / deep-link "scrollToRow" path scrolled the list and
resolved the highlight inside the same synchronous callback, so the selector
rect was captured before the reveal-scroll layout settled. The highlight was
then drawn offset from the intended row (and for far rows, off-screen).

This splits it: scroll first, then post the highlight after the layout
settles, and re-resolve the slug so a stale index can't pick the wrong row.



https://github.com/user-attachments/assets/71fa3dc2-df34-46eb-a805-a705b68d062e

